### PR TITLE
Fix ID Matching

### DIFF
--- a/evaluation/modal_api.py
+++ b/evaluation/modal_api.py
@@ -88,7 +88,7 @@ def evaluate_spreadsheet(request_data: dict):
         # Find the data entry for this ID
         data_entry = None
         for data in dataset:
-            if data["id"] == spreadsheet_id:
+            if str(data["id"]) == spreadsheet_id:
                 data_entry = data
                 break
 


### PR DESCRIPTION
Modal endpoint matches directly, which means if the id in the .json is an int and the request is a string, it fails and early returns incorrectly.